### PR TITLE
TACODEV-909: update default namespace for cluster resources of cluste…

### DIFF
--- a/tks-cluster/aws/resources.yaml
+++ b/tks-cluster/aws/resources.yaml
@@ -13,7 +13,7 @@ spec:
     name: cluster-api-aws
     version: 0.3.1
   releaseName: cluster-api-aws
-  targetNamespace: default
+  targetNamespace: argo
   values:
     sshKeyName: TO_BE_FIXED
     cluster:

--- a/tks-cluster/aws/site-values.yaml
+++ b/tks-cluster/aws/site-values.yaml
@@ -10,7 +10,7 @@ global:
 charts:
 - name: cluster-api-aws
   override:
-    sshKeyName: default
+    sshKeyName: taco
     cluster.name: $(clusterName)
     cluster.region: TO_BE_FIXED
     cluster.bastion.enabled: false


### PR DESCRIPTION
…r api and default ssh-key for aws vm

cluster api의 자원들 배포대상 변경 (argo) 그리고 ssh-key 변경(taco)